### PR TITLE
docs: update SECURITY.md and README.md for accuracy

### DIFF
--- a/DEVELOPMENT_ROADMAP.md
+++ b/DEVELOPMENT_ROADMAP.md
@@ -43,7 +43,7 @@
 - 🚧 **Capability validation logic** - token structure complete, enforcement missing
 
 **Completed Security Items:**
-- ✅ **Secure key storage** - OS keyring-only, no plaintext keys (PR #22)
+- ✅ **Secure key storage** - OS keyring-first with plaintext fallback for compatibility (PR #22)
 - ✅ **Session security** - Encrypted sessions, rate limiting (PR #24)
 - ✅ **DoS protection** - Request size limits, chunked transfer timeouts (PR #25)
 - ✅ **Timing attack mitigation** - Constant-time operations, dummy verification (PR #25)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Replace bearer tokens with cryptographic proof-of-possession. Signet provides to
 - **Not audited** - use for development only
 - Experimental largely due to [`go-cms`](https://github.com/jamestexas/go-cms) (no external review, passes OpenSSL interop tests)
 - **Platform:** Built for macOS, should work on Linux (minimal testing)
+- **Key storage:** Defaults to OS keyring; falls back to plaintext `~/.signet/master.key` when the keyring is unavailable or initialized with `--insecure`
 - See [SECURITY.md](SECURITY.md) for security limitations and best practices
 
 ## What Works Today

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,11 +13,16 @@
 ## Known Security Limitations
 
 ### v0.0.1 Alpha
-- Keys stored in OS keyring (falls back to plaintext if keyring unavailable)
-- Not all features migrated to secure storage yet
+- Keys stored in the OS keyring by default; falls back to plaintext `~/.signet/master.key` when the keyring is unavailable or Signet is initialized with `--insecure`
+- `signet authority` and other long-running automation currently use file-based master keys (secure keyring support planned)
 - No security audit performed
 - APIs will change before v1.0
 - Tested primarily on macOS (Linux should work but minimal testing)
+
+#### Keyring memory safety
+- OS keyring integration uses `github.com/zalando/go-keyring`, which stores secrets as Go strings
+- Go strings are immutable, so secrets may persist in process memory until garbage collection
+- Private keys are zeroed after use, but short-lived remnants may exist (see `pkg/cli/keystore/secure.go`)
 
 ### What IS Secure
 - Ed25519 cryptographic operations


### PR DESCRIPTION
## Summary
- Update SECURITY.md to reflect OS keyring storage (with plaintext fallback)
- Clarify README.md experimental status due to unreviewed go-cms library
- Add platform compatibility notes (macOS primary, Linux minimal testing)
- Convert architecture ASCII art to GitHub markdown table
- Soften "first" claim to "one of the first" (safer)
- Link to SECURITY.md as single source of truth for security info

## Changes
**SECURITY.md:**
- Keys now in OS keyring (falls back to plaintext if unavailable)
- Added platform testing status
- Removed outdated plaintext storage warnings

**README.md:**
- Status section clarifies experimental nature (go-cms not reviewed)
- Architecture diagram now uses clean GitHub table format
- Platform compatibility clearly stated
- Links to SECURITY.md to avoid duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)