### PR TITLE
security: SHA-pin notme/action ref

### DIFF
--- a/.github/workflows/gha-identity.yml
+++ b/.github/workflows/gha-identity.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Exchange OIDC → signet bridge cert
         id: signet
         if: '!inputs.skip_bridge_cert'
-        uses: agentic-research/notme/action@main
+        uses: agentic-research/notme/action@2c540af # main 2026-04-02
         with:
           audience: ${{ inputs.bridge_audience }}
           authority_url: https://auth.notme.bot


### PR DESCRIPTION
Pin agentic-research/notme/action from @main to @2c540af. Mutable refs are the Trivy attack vector.