### PR TITLE
security: enforce least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   test:
     name: Test Suite (Pure Go)
@@ -119,6 +121,8 @@ jobs:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,6 +28,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: write  # Need write to comment
       issues: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,6 +14,8 @@ on:
         required: true
         type: number
 
+permissions: {}
+
 jobs:
   claude-review:
     # Only run if:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,7 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 env:
   TAG: ${{ inputs.tag || github.ref_name }}
@@ -21,6 +20,8 @@ jobs:
   build:
     name: Build (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -63,6 +64,8 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -11,8 +11,7 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 env:
   TAG: ${{ inputs.tag || github.ref_name }}
@@ -21,6 +20,8 @@ jobs:
   build-native:
     name: Build staticlib (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +69,8 @@ jobs:
   build-wasm:
     name: Build Wasm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -94,6 +97,8 @@ jobs:
   build-header:
     name: Generate C header
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -115,6 +120,8 @@ jobs:
     name: Create Release
     needs: [build-native, build-wasm, build-header]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/signet-resign.yml
+++ b/.github/workflows/signet-resign.yml
@@ -44,6 +44,7 @@ jobs:
     needs: identity
     permissions:
       contents: write
+      pull-requests: read
 
     # Only run if:
     # 1. Approval is submitted (or manual trigger)

--- a/.github/workflows/signet-resign.yml
+++ b/.github/workflows/signet-resign.yml
@@ -26,9 +26,7 @@ concurrency:
   group: signet-resign-${{ github.event.pull_request.number || github.event.inputs.pr_number || 'manual' }}
   cancel-in-progress: false
 
-permissions:
-  id-token: write
-  contents: write
+permissions: {}
 
 jobs:
   identity:
@@ -44,6 +42,8 @@ jobs:
     name: Re-sign approved PR
     runs-on: ubuntu-latest
     needs: identity
+    permissions:
+      contents: write
 
     # Only run if:
     # 1. Approval is submitted (or manual trigger)


### PR DESCRIPTION
## Summary
- Set top-level `permissions: {}` on all 6 workflows (ci, claude, claude-code-review, release, rust-release, signet-resign)
- Grant scoped permissions per-job: `contents: read` for checkouts, `contents: write` only for release/re-sign jobs
- Prevents over-privileged `GITHUB_TOKEN` from leaking across jobs

## Affected Workflows
| Workflow | Change |
|----------|--------|
| `ci.yml` | Add top-level `permissions: {}`, `contents: read` on benchmarks job |
| `claude.yml` | Add top-level `permissions: {}` |
| `claude-code-review.yml` | Add top-level `permissions: {}` |
| `release.yml` | Top-level `permissions: {}`, `contents: read` on build, `contents: write` on release |
| `rust-release.yml` | Top-level `permissions: {}`, `contents: read` on build/wasm/header, `contents: write` on release |
| `signet-resign.yml` | Top-level `permissions: {}`, `contents: write` on resign job only |

## Test plan
- [ ] CI passes (workflows can still read code, run tests)
- [ ] Release workflow can still create GitHub releases (`contents: write` on release job)
- [ ] Re-sign workflow can still push commits (`contents: write` on resign job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)