### PR TITLE
test(signet): pkg/git unit tests for sign/verify pure-function seams

### DIFF
--- a/pkg/git/sign_test.go
+++ b/pkg/git/sign_test.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/sha1" // #nosec G505 — parity with certHexFingerprint's documented use
+	"crypto/sha1"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
@@ -35,7 +35,7 @@ func TestCertHexFingerprint_DeterministicSHA1(t *testing.T) {
 	cert := mintTestCert(t)
 	got := certHexFingerprint(cert)
 
-	expected := sha1.Sum(cert.Raw)
+	expected := sha1.Sum(cert.Raw) // #nosec G401 — parity with certHexFingerprint's documented use; not security
 	want := hex.EncodeToString(expected[:])
 	if got != want {
 		t.Fatalf("fingerprint mismatch:\n got: %s\nwant: %s", got, want)

--- a/pkg/git/sign_test.go
+++ b/pkg/git/sign_test.go
@@ -1,0 +1,119 @@
+package git
+
+import (
+	"bufio"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha1" // #nosec G505 — parity with certHexFingerprint's documented use
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCertHexFingerprint_NilCert(t *testing.T) {
+	got := certHexFingerprint(nil)
+	want := strings.Repeat("0", 40)
+	if got != want {
+		t.Fatalf("nil cert: got %q, want all-zero fingerprint %q", got, want)
+	}
+}
+
+func TestCertHexFingerprint_EmptyRaw(t *testing.T) {
+	got := certHexFingerprint(&x509.Certificate{})
+	want := strings.Repeat("0", 40)
+	if got != want {
+		t.Fatalf("empty Raw: got %q, want all-zero fingerprint %q", got, want)
+	}
+}
+
+func TestCertHexFingerprint_DeterministicSHA1(t *testing.T) {
+	cert := mintTestCert(t)
+	got := certHexFingerprint(cert)
+
+	expected := sha1.Sum(cert.Raw)
+	want := hex.EncodeToString(expected[:])
+	if got != want {
+		t.Fatalf("fingerprint mismatch:\n got: %s\nwant: %s", got, want)
+	}
+	if len(got) != 40 {
+		t.Fatalf("expected 40-char SHA-1 hex, got %d chars", len(got))
+	}
+
+	again := certHexFingerprint(cert)
+	if again != got {
+		t.Fatalf("fingerprint not deterministic across calls: %s vs %s", got, again)
+	}
+}
+
+func TestEmitStatus_StatusFdZero_NoOp(t *testing.T) {
+	emitStatus(0, "[GNUPG:] SHOULD_NOT_APPEAR")
+}
+
+func TestEmitStatus_StatusFdNegative_NoOp(t *testing.T) {
+	emitStatus(-1, "[GNUPG:] SHOULD_NOT_APPEAR")
+}
+
+func TestEmitStatus_WritesLineToFd(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	line := "[GNUPG:] BEGIN_SIGNING"
+	emitStatus(int(w.Fd()), line)
+
+	scanner := bufio.NewScanner(r)
+	done := make(chan struct{})
+	var got string
+	go func() {
+		if scanner.Scan() {
+			got = scanner.Text()
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for emitStatus to write the line")
+	}
+
+	if got != line {
+		t.Fatalf("got %q, want %q", got, line)
+	}
+}
+
+// mintTestCert builds a self-signed Ed25519 cert good enough to exercise
+// fingerprint code paths. Not a CA cert — just something with a populated
+// cert.Raw.
+func mintTestCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-cert"},
+		NotBefore:    time.Now().Add(-1 * time.Minute),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, priv.Public(), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}

--- a/pkg/git/verify_test.go
+++ b/pkg/git/verify_test.go
@@ -42,6 +42,15 @@ func TestGetStatusWriter_CustomFdReturnsFileAndCleanupCloses(t *testing.T) {
 	t.Cleanup(func() { _ = r.Close() })
 
 	writer, cleanup := getStatusWriter(int(w.Fd()))
+	// Register cleanup defensively: if any t.Fatalf below fires before the
+	// manual cleanup() call, the pipe-writer fd would otherwise leak. The
+	// `called` flag prevents a double-close.
+	var called bool
+	t.Cleanup(func() {
+		if !called {
+			cleanup()
+		}
+	})
 
 	got, ok := writer.(*os.File)
 	if !ok {
@@ -75,6 +84,7 @@ func TestGetStatusWriter_CustomFdReturnsFileAndCleanupCloses(t *testing.T) {
 	}
 
 	cleanup()
+	called = true
 
 	if _, err := got.WriteString("after-cleanup\n"); err == nil {
 		t.Fatal("expected write after cleanup() to fail (file closed), but it succeeded")

--- a/pkg/git/verify_test.go
+++ b/pkg/git/verify_test.go
@@ -1,0 +1,82 @@
+package git
+
+import (
+	"bufio"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGetStatusWriter_FdZeroDefaultsStderr(t *testing.T) {
+	w, cleanup := getStatusWriter(0)
+	t.Cleanup(cleanup)
+
+	if w != os.Stderr {
+		t.Fatalf("statusFd=0: expected os.Stderr, got %T", w)
+	}
+}
+
+func TestGetStatusWriter_FdOneIsStdout(t *testing.T) {
+	w, cleanup := getStatusWriter(1)
+	t.Cleanup(cleanup)
+
+	if w != os.Stdout {
+		t.Fatalf("statusFd=1: expected os.Stdout, got %T", w)
+	}
+}
+
+func TestGetStatusWriter_FdTwoIsStderr(t *testing.T) {
+	w, cleanup := getStatusWriter(2)
+	t.Cleanup(cleanup)
+
+	if w != os.Stderr {
+		t.Fatalf("statusFd=2: expected os.Stderr, got %T", w)
+	}
+}
+
+func TestGetStatusWriter_CustomFdReturnsFileAndCleanupCloses(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	writer, cleanup := getStatusWriter(int(w.Fd()))
+
+	got, ok := writer.(*os.File)
+	if !ok {
+		t.Fatalf("custom fd: expected *os.File, got %T", writer)
+	}
+	if got.Fd() != w.Fd() {
+		t.Fatalf("custom fd: returned file wraps fd %d, want %d", got.Fd(), w.Fd())
+	}
+
+	const line = "[GNUPG:] CUSTOM_FD_TEST"
+	if _, err := got.WriteString(line + "\n"); err != nil {
+		t.Fatalf("write to status fd: %v", err)
+	}
+
+	scanner := bufio.NewScanner(r)
+	done := make(chan struct{})
+	var read string
+	go func() {
+		if scanner.Scan() {
+			read = scanner.Text()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out reading from status pipe")
+	}
+	if read != line {
+		t.Fatalf("read %q, want %q", read, line)
+	}
+
+	cleanup()
+
+	if _, err := got.WriteString("after-cleanup\n"); err == nil {
+		t.Fatal("expected write after cleanup() to fail (file closed), but it succeeded")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the zero-direct-test gap on \`pkg/git/sign.go\` and \`pkg/git/verify.go\` flagged by **[signet-a8b5e1]**. Adds 10 unit tests covering the pure-function seams that can be exercised without keystore plumbing or stdin/stdout redirection.

## Coverage added

**sign.go:**
- \`certHexFingerprint\` — nil cert, empty Raw, deterministic SHA-1 hex, 40-char width, idempotence
- \`emitStatus\` — \`statusFd<=0\` no-op (covers fd=0 and fd=-1), \`statusFd>0\` writes line to fd (verified via \`os.Pipe\`)

**verify.go:**
- \`getStatusWriter\` — fd=0 → stderr (safe default), fd=1 → stdout, fd=2 → stderr, custom fd → \`*os.File\` with cleanup() that closes the underlying file (verified via \`os.Pipe\` + post-cleanup write fails)

## Not covered (intentional, P2 scope)

End-to-end roundtrip of \`SignCommit\` → \`VerifySignature\` requires Identity construction (master key + optional bridge cert) and stdin/stdout plumbing. Worth a follow-up: either a new integration-test bead or an expansion of \`scripts/testing/test_integration.sh\` (which already exercises the full git-commit signing workflow in Docker).

## Test plan

- [x] \`go test -v ./pkg/git/\` — all tests pass (existing identity_test.go + 10 new)
- [x] \`go test -race ./pkg/git/\` — clean under race detector
- [x] \`go vet ./pkg/git/\` — clean
- [x] No behavior changes — tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)