### PR TITLE
sec(ci): deny-by-default permissions on remaining workflow files [signet-b26b6e]

### DIFF
--- a/.github/workflows/gha-identity.yml
+++ b/.github/workflows/gha-identity.yml
@@ -81,6 +81,8 @@ on:
         description: 'Bridge cert pair expiry as Unix timestamp (notme default TTL = 5 minutes).'
         value: ${{ jobs.exchange.outputs.expires_at }}
 
+permissions: {}
+
 jobs:
   exchange:
     name: OIDC Exchange

--- a/.github/workflows/oidc-signing.yml
+++ b/.github/workflows/oidc-signing.yml
@@ -5,14 +5,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   oidc-signing-test:
     name: OIDC Token Exchange E2E
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # mint GHA OIDC token for the exchange
+      contents: read    # checkout
 
     steps:
       - name: Checkout code

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,13 +7,14 @@ on:
   pull_request:
     paths: ['rs/**']
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -28,6 +29,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -43,6 +46,8 @@ jobs:
   wasm:
     name: Wasm build check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable


### PR DESCRIPTION
## Summary

Closes **[signet-b26b6e]** (P0, open since 2026-04-01). The bead body cited 6 workflows needing hardening; 5 of those were already fixed in earlier work. This PR closes the remaining gap by applying the deny-by-default + per-job pattern to the three workflows that still had it inverted:

- \`gha-identity.yml\` — added \`permissions: {}\` at top-level (was missing entirely; per-job was already correct)
- \`oidc-signing.yml\` — moved \`id-token: write\` + \`contents: read\` from top-level into the \`oidc-signing-test\` job
- \`rust-ci.yml\` — moved \`contents: read\` from top-level into each of \`test\`, \`lint\`, \`wasm\` jobs

## Why this matters

A top-level \`id-token: write\` (oidc-signing.yml) is the most concerning of the three — any future job added to that file would silently inherit the ability to mint OIDC tokens. With this PR, every job has to declare its intent explicitly, which is the auditable shape.

\`rust-ci.yml\`'s \`contents: read\` is much lower risk, but applying the same pattern uniformly means a future "publish-crate" or similar job has to ask explicitly for any write capability.

\`gha-identity.yml\` is a reusable workflow (\`workflow_call\`) — permissions are inherited from the caller — but adding \`permissions: {}\` at top is still good hygiene: future jobs in this file default to nothing, not the caller's (potentially-broader) grant.

## Test plan

- [x] All three files still parse as valid YAML (verified the per-job permissions blocks are at correct indentation)
- [ ] CI runs on this PR will exercise both \`ci.yml\` (already hardened) and \`rust-ci.yml\` (newly hardened) — verifies the per-job \`contents: read\` is sufficient for the existing steps
- [ ] \`oidc-signing.yml\` triggers on push-to-main, so will be exercised post-merge
- [ ] \`gha-identity.yml\` is a reusable workflow exercised by \`signet-resign.yml\` — also post-merge

## Non-goals

No behavior change to any existing job. This is purely a scoping change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)