### PR TITLE
docs(schema): consolidate cross-language type-sync pointers [signet-683223]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,9 @@ This directory contains technical documentation for the Signet project.
 ## Organization
 
 ### [`design/`](./design/)
-Stable design documents explaining technical choices and architecture:
+Stable design documents explaining technical choices and architecture.
+
+**Numbered ADRs** (chronological design decisions):
 - `001-signet-tokens.md` - Token format and structure
 - `002-protocol-spec.md` - Wire format and protocol
 - `003-sdk.md` - SDK architecture
@@ -13,7 +15,19 @@ Stable design documents explaining technical choices and architecture:
 - `005-memory-security.md` - Sensitive data handling
 - `006-revocation.md` - Revocation strategy
 - `007-http-pop.md` - HTTP proof-of-possession
+- `007-progressive-identity-disclosure.md` - Progressive identity disclosure
+- `008-pluggable-signer-backends.md` - Pluggable signer backends
+- `009-macos-touchid-signer.md` - macOS Touch ID signer
+- `010-semantic-capability-protocol.md` - Semantic capability protocol
+- `011-policy-bundles-scim.md` - Trust policy bundles + SCIM
+
+**Cross-cutting reference docs** (not chronological):
+- `code-overlap-audit.md` - Audit of overlap between sigid / sigpol / capabilities
 - `cross-language-schema.md` - Where cross-language types live (notme/schema canonical, the type/wire-format split)
+- `edge-signing-contract.md` - Edge-signer contract
+- `integration-seams.md` - Integration seams across signet subsystems
+- `sigid-requirements.md` - sigid module requirements (forward-looking)
+- `sigpol-requirements.md` - sigpol module requirements (forward-looking)
 
 ### [`implementation/`](./implementation/)
 Historical and work-in-progress feature implementation guides (may be partially outdated):

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Stable design documents explaining technical choices and architecture:
 - `005-memory-security.md` - Sensitive data handling
 - `006-revocation.md` - Revocation strategy
 - `007-http-pop.md` - HTTP proof-of-possession
+- `cross-language-schema.md` - Where cross-language types live (notme/schema canonical, the type/wire-format split)
 
 ### [`implementation/`](./implementation/)
 Historical and work-in-progress feature implementation guides (may be partially outdated):

--- a/docs/design/cross-language-schema.md
+++ b/docs/design/cross-language-schema.md
@@ -32,15 +32,21 @@ Rust from `notme/gen/rust/identity` when wired).
 | `RevocationReason` | Enum: `epochMismatch / unknownKey / rollbackAttack / bundleInvalid / bundleStale`. |
 | `RevocationResult` | `(revoked: Bool, reason: RevocationReason)` returned by the checker. |
 
-### Certificates (ADR-008 dual-cert PoP)
+### Certificates (dual-cert PoP, per notme schema §008)
+
+The dual-cert pair (P-256 mTLS + Ed25519 signing) is a notme schema-version
+convention (see `BridgeCertPair`'s "008:" comment in
+[`notme/schema/identity.capnp`][notme-capnp]); it is not a signet ADR. The
+nearest signet design doc is [`004-bridge-certs.md`](./004-bridge-certs.md),
+which covers the single-cert bridge flow that `BridgeCertResult` represents.
 
 | Capnp struct | Notes |
 |---|---|
-| `BridgeCertResult` | Legacy single-cert result. Kept for wire compat with `DispatchPredicate`; new code should prefer `BridgeCertPair`. |
-| `BridgeCertPair` | The 008 dual-cert result: P-256 mTLS cert + Ed25519 signing cert, with `binding` field proving both certs came from the same OIDC exchange. |
+| `BridgeCertResult` | Legacy single-cert result. Kept for wire compat with `DispatchPredicate`; new code should prefer `BridgeCertPair`. Aligns with signet ADR-004 (bridge certs). |
+| `BridgeCertPair` | Dual-cert result: P-256 mTLS cert + Ed25519 signing cert, with `binding` field proving both certs came from the same OIDC exchange. notme schema-version 008. |
 | `CertScope` | Enum: `bridgeCert / authorityManage / certMint`. |
 | `AuthorityState` | `(epoch, keyId)` snapshot for liveness probes. |
-| `CertPairRequest` / `CertPairPublicKeys` / `CertPairPoP` | The request shapes for the 008 PoP exchange. |
+| `CertPairRequest` / `CertPairPublicKeys` / `CertPairPoP` | The request shapes for the dual-cert PoP exchange. |
 | `CertRequest` | Legacy single-cert request shape. |
 
 ### Authentication (proofs)
@@ -58,7 +64,13 @@ Rust from `notme/gen/rust/identity` when wired).
 | `HandoffPredicate` | The phase-handoff attestation with chain hash: `(fromPhase, toPhase, summary, filesChanged, commitShas, previousChainHash, chainHash, signingCert, certPair)`. |
 | `BeadRef`, `AgentIdentity`, `PipelineContext` | Sub-records for `DispatchPredicate`. |
 
-### Signing Oracle (ssh-agent pattern, ADR-008 §oracle)
+### Signing Oracle (ssh-agent-pattern delegated signing)
+
+The oracle pattern is described inline in the capnp schema (`SignRequest`'s
+comment block in [`notme/schema/identity.capnp`][notme-capnp]) and conceptually
+sits in the same neighborhood as signet's pluggable signer backends design
+([`008-pluggable-signer-backends.md`](./008-pluggable-signer-backends.md)),
+but there is no dedicated signet ADR for the protocol shape.
 
 | Capnp struct | Notes |
 |---|---|
@@ -71,9 +83,9 @@ A follow-up bead may move them in if/when cross-language consumers appear.
 
 | Type | Location | Tracking |
 |---|---|---|
-| `MasterKeyDescriptor` | `pkg/signet/signet.go` (L10, commit `8a79f9a`) | [`signet-2f6b68`][bead-2f6b68] — move into `notme/schema/identity.capnp` via schema-bridge codegen so `TrustDomain` is a shared type. |
-| `Token` (CBOR fields 1-19) | `pkg/signet/token.go` | No bead. Token's wire format is COSE Sign1 with a CBOR payload; cross-language consumers parse CBOR directly today rather than going through a schema. If a TS/Rust consumer appears that wants typed fields, file a bead. |
-| `Boundary`, `Environment`, `Attestation`, `Context`, `Provenance` (the sigid types) | `pkg/sigid/...` | The shape mirrors capnp-style structured records but is not in `identity.capnp`. The sigid drift bead [`signet-a8e3a7`][bead-a8e3a7] covers the broader question of where sigid types should live. |
+| `MasterKeyDescriptor` | [`pkg/signet/signet.go:37`](../../pkg/signet/signet.go) | Bead `signet-2f6b68` — move into `notme/schema/identity.capnp` via schema-bridge codegen so `TrustDomain` is a shared type. |
+| `Token` (CBOR fields 1-19) | [`pkg/signet/token.go`](../../pkg/signet/token.go) | No bead. Token's wire format is COSE Sign1 with a CBOR payload; cross-language consumers parse CBOR directly today rather than going through a schema. If a TS/Rust consumer appears that wants typed fields, file a bead. |
+| `Boundary`, `Environment`, `Attestation`, `Context`, `Provenance` (the sigid types) | [`pkg/sigid/`](../../pkg/sigid) | The shape mirrors capnp-style structured records but is not in `identity.capnp`. Bead `signet-a8e3a7` covers the broader question of where sigid types should live. |
 
 ## Wire-format split
 
@@ -87,7 +99,7 @@ channel is governed by the protocol, not the schema:
 | HTTP request bodies (authority API, MCP) | JSON | Standard REST shape; humans read it; not cryptographically canonical. |
 | CA bundle signature input | Canonical CBOR (Go) — see note below | Deterministic bytes for cross-version verification. |
 
-**Open contract gap (deferred):** The bead [`signet-683223`][bead-683223] flags
+**Open contract gap (deferred):** Bead `signet-683223` flags
 that TypeScript clients have historically signed `CABundle` with **JSON +
 alphabetical key sort** while Go signs with **canonical CBOR**. These produce
 different byte sequences and are not cryptographically interoperable. The
@@ -119,8 +131,10 @@ bead with a "pick one canonical-bytes encoding, deprecate the other" decision.
 
 [notme-capnp]: https://github.com/agentic-research/notme/blob/main/schema/identity.capnp
 [notme-schema-readme]: https://github.com/agentic-research/notme/blob/main/schema/README.md
-[bead-2f6b68]: https://github.com/agentic-research/signet/issues — bead signet-2f6b68
-[bead-a8e3a7]: https://github.com/agentic-research/signet/issues — bead signet-a8e3a7
-[bead-683223]: https://github.com/agentic-research/signet/issues — bead signet-683223
 [adr-002]: ./002-protocol-spec.md
 [adr-010-notme]: https://github.com/agentic-research/notme/blob/main/docs/adr/010-json-vs-cbor.md
+
+> **Bead references:** beads are tracked via the `rsry` MCP / Dolt
+> (`.beads/` directories), not as GitHub issues. Search a bead by ID
+> via `rsry_bead_search` from any repo working tree. The IDs referenced
+> here are `signet-2f6b68`, `signet-a8e3a7`, `signet-683223`.

--- a/docs/design/cross-language-schema.md
+++ b/docs/design/cross-language-schema.md
@@ -1,0 +1,126 @@
+# Cross-Language Schema — Where Types Live
+
+**Status:** Reference doc consolidating the schema-source-of-truth pointers that
+were previously scattered across README.md, `docs/spiffe-vocabulary-map.md`, and
+`docs/sigstore-vocabulary-map.md`.
+
+**Scope:** This doc covers **type definitions** for cross-language consumers
+(Go, TypeScript, Rust). It does **not** specify wire format — see
+[Wire-format split](#wire-format-split) below for the separate contract.
+
+**Why this exists:** Several signet types appear in code generated from a
+Cap'n Proto schema that lives in a sibling repo (`notme`). Without a single
+pointer doc, it's easy for a new contributor to "fix" a type in
+`pkg/signet/...` and not realize the canonical definition lives elsewhere —
+and that the fix needs to land in the schema first.
+
+## Canonical source: `notme/schema/identity.capnp`
+
+The schema file at [`agentic-research/notme:schema/identity.capnp`][notme-capnp]
+is the **single source of truth** for the following types. Do not redefine them
+in signet — import the generated bindings instead (Go from
+`notme/gen/go/identity`, TypeScript + Zod from `notme/gen/ts/identity`,
+Rust from `notme/gen/rust/identity` when wired).
+
+### Revocation (signet ADR-006)
+
+| Capnp struct | Notes |
+|---|---|
+| `CABundle` | The signed CA bundle that carries `(epoch, seqno, keys, signature)`. The signet revocation checker (`pkg/revocation/checker.go`) consumes this shape. |
+| `KeyEntry` | One row in `CABundle.keys` — `(kid, publicKey)`. |
+| `TokenClaims` | The `(keyId, epoch)` pair embedded in tokens for revocation matching. |
+| `RevocationReason` | Enum: `epochMismatch / unknownKey / rollbackAttack / bundleInvalid / bundleStale`. |
+| `RevocationResult` | `(revoked: Bool, reason: RevocationReason)` returned by the checker. |
+
+### Certificates (ADR-008 dual-cert PoP)
+
+| Capnp struct | Notes |
+|---|---|
+| `BridgeCertResult` | Legacy single-cert result. Kept for wire compat with `DispatchPredicate`; new code should prefer `BridgeCertPair`. |
+| `BridgeCertPair` | The 008 dual-cert result: P-256 mTLS cert + Ed25519 signing cert, with `binding` field proving both certs came from the same OIDC exchange. |
+| `CertScope` | Enum: `bridgeCert / authorityManage / certMint`. |
+| `AuthorityState` | `(epoch, keyId)` snapshot for liveness probes. |
+| `CertPairRequest` / `CertPairPublicKeys` / `CertPairPoP` | The request shapes for the 008 PoP exchange. |
+| `CertRequest` | Legacy single-cert request shape. |
+
+### Authentication (proofs)
+
+| Capnp struct | Notes |
+|---|---|
+| `Proof` | Union: `ghaOidc / passkey / bootstrapCode`. The 'how the caller authenticated' tag. |
+| `GHAClaims` | The full set of GitHub Actions OIDC claims (16 fields: `iss`, `sub`, `aud`, `repository`, `actor`, `workflow`, `jti`, ...). Used by signet's GHA OIDC provider in `pkg/oidc/`. |
+
+### APAS Attestation Predicates
+
+| Capnp struct | Notes |
+|---|---|
+| `DispatchPredicate` | The bead-dispatch attestation: `(beadRef, agent, pipeline, signingCert, certPair)`. |
+| `HandoffPredicate` | The phase-handoff attestation with chain hash: `(fromPhase, toPhase, summary, filesChanged, commitShas, previousChainHash, chainHash, signingCert, certPair)`. |
+| `BeadRef`, `AgentIdentity`, `PipelineContext` | Sub-records for `DispatchPredicate`. |
+
+### Signing Oracle (ssh-agent pattern, ADR-008 §oracle)
+
+| Capnp struct | Notes |
+|---|---|
+| `SignRequest` | `(digest, algorithm, purpose)` — the request shape for the delegated-signer protocol. |
+
+## Types that are signet-only (not yet in capnp)
+
+These types are defined in signet Go and are not in `notme/schema/identity.capnp`.
+A follow-up bead may move them in if/when cross-language consumers appear.
+
+| Type | Location | Tracking |
+|---|---|---|
+| `MasterKeyDescriptor` | `pkg/signet/signet.go` (L10, commit `8a79f9a`) | [`signet-2f6b68`][bead-2f6b68] — move into `notme/schema/identity.capnp` via schema-bridge codegen so `TrustDomain` is a shared type. |
+| `Token` (CBOR fields 1-19) | `pkg/signet/token.go` | No bead. Token's wire format is COSE Sign1 with a CBOR payload; cross-language consumers parse CBOR directly today rather than going through a schema. If a TS/Rust consumer appears that wants typed fields, file a bead. |
+| `Boundary`, `Environment`, `Attestation`, `Context`, `Provenance` (the sigid types) | `pkg/sigid/...` | The shape mirrors capnp-style structured records but is not in `identity.capnp`. The sigid drift bead [`signet-a8e3a7`][bead-a8e3a7] covers the broader question of where sigid types should live. |
+
+## Wire-format split
+
+This doc covers **type definitions only**. The wire format used on any given
+channel is governed by the protocol, not the schema:
+
+| Channel | Wire format | Why |
+|---|---|---|
+| Signet tokens (`SIG1.<CBOR>.<COSE_Sign1>`) | Canonical CBOR per RFC 8949 §4.2, integer-keyed maps | Deterministic bytes for Ed25519 sign/verify; integer keys for compact tokens. See `pkg/revocation/checker.go:168-188`. |
+| CMS / PKCS#7 signatures (git, file signing) | RFC 5652 DER | Sigstore / gpgsm / gitsign compat. |
+| HTTP request bodies (authority API, MCP) | JSON | Standard REST shape; humans read it; not cryptographically canonical. |
+| CA bundle signature input | Canonical CBOR (Go) — see note below | Deterministic bytes for cross-version verification. |
+
+**Open contract gap (deferred):** The bead [`signet-683223`][bead-683223] flags
+that TypeScript clients have historically signed `CABundle` with **JSON +
+alphabetical key sort** while Go signs with **canonical CBOR**. These produce
+different byte sequences and are not cryptographically interoperable. The
+capnp schema does not resolve this — schema parity ≠ wire-format parity. This
+contract gap is a separate, **functional** problem and is intentionally **not
+in scope** for the discoverability fix that this doc lands. It needs its own
+bead with a "pick one canonical-bytes encoding, deprecate the other" decision.
+
+## How to add a type that needs cross-language sync
+
+1. **Define it in `notme/schema/identity.capnp`** first — the schema is the
+   contract. Open a PR there before touching signet.
+2. Once merged in notme, the codegen workflow (in notme) produces
+   `notme/gen/go/identity/*.go`, `notme/gen/ts/identity/*.ts`, and
+   `notme/gen/rust/identity/*.rs`.
+3. In signet, import from `github.com/agentic-research/notme/gen/go/identity`
+   rather than redeclaring the struct.
+4. If you find yourself writing `type X struct { ... }` in signet for
+   something that other-language consumers will need, that's the signal:
+   send it to notme first.
+
+## See also
+
+- `docs/spiffe-vocabulary-map.md` — how SPIFFE vocabulary maps onto signet types
+- `docs/sigstore-vocabulary-map.md` — how Sigstore vocabulary maps onto signet types
+- [notme/schema/README.md][notme-schema-readme] — the schema's own docs in the notme repo
+- [signet ADR-002 §2.3][adr-002] — wire-format spec for tokens
+- [notme ADR-010][adr-010-notme] — JSON-vs-CBOR split for HTTP-vs-canonical
+
+[notme-capnp]: https://github.com/agentic-research/notme/blob/main/schema/identity.capnp
+[notme-schema-readme]: https://github.com/agentic-research/notme/blob/main/schema/README.md
+[bead-2f6b68]: https://github.com/agentic-research/signet/issues — bead signet-2f6b68
+[bead-a8e3a7]: https://github.com/agentic-research/signet/issues — bead signet-a8e3a7
+[bead-683223]: https://github.com/agentic-research/signet/issues — bead signet-683223
+[adr-002]: ./002-protocol-spec.md
+[adr-010-notme]: https://github.com/agentic-research/notme/blob/main/docs/adr/010-json-vs-cbor.md


### PR DESCRIPTION
## Summary

Closes the **discoverability** part of **[signet-683223]** (P0, open since 2026-03-29). The bead asks for "Cap'n Proto schemas for cross-language type parity (CABundle, GHAClaims, APAS predicates)". Those schemas already exist — they live in [\`notme/schema/identity.capnp\`][notme-capnp] as the single source of truth, with codegen producing Go/TypeScript/Rust bindings. The gap was discoverability: signet had only a one-liner pointer in README.md and scattered references in the SPIFFE/Sigstore vocab maps. A contributor "fixing" a type in \`pkg/signet/...\` could miss that the canonical definition is in a sibling repo.

## What this PR ships (docs only)

\`docs/design/cross-language-schema.md\` — a consolidation doc that:

1. **Lists every type canonical in notme/schema** with the struct/field names each carries, broken out by category: revocation (ADR-006), certs (ADR-008), auth proofs, APAS predicates, signing oracle.
2. **Lists signet-only types not yet in capnp** (\`MasterKeyDescriptor\`, \`Token\`, sigid types) with links to the tracking beads ([\`signet-2f6b68\`], [\`signet-a8e3a7\`]).
3. **Wire-format split table**: capnp = type sync; wire format on any channel is governed by the protocol (CBOR for tokens, DER for CMS, JSON for HTTP).
4. **\"How to add a type that needs cross-language sync\"** section spelling out the contract: schema PR to notme first, then import generated bindings in signet.

Also adds the new doc to \`docs/README.md\`'s design index.

## Explicitly deferred (called out in the doc)

The bead body opens with:
> TypeScript signs CABundles with JSON + alphabetical key sort. Go signs with CBOR canonical encoding. These produce different byte sequences — cross-language verification will fail silently

That's a **functional** wire-format-divergence bug, not a schema-sync problem. The capnp schema doesn't resolve it — schema parity ≠ wire-format parity. The doc names this as an "Open contract gap (deferred)" pending a separate bead that picks one canonical encoding and deprecates the other. Per the user's "nothing functional ideally," not in scope here.

## Test plan

- [x] Doc renders correctly (no broken table syntax)
- [x] All cross-references resolve to real files (\`002-protocol-spec.md\`, etc.)
- [x] No code changes — \`docs/\` only

[notme-capnp]: https://github.com/agentic-research/notme/blob/main/schema/identity.capnp
[\`signet-2f6b68\`]: # tracking bead — move MasterKeyDescriptor into capnp
[\`signet-a8e3a7\`]: # tracking bead — sigid canonical home decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)