### PR TITLE
feat(revocation): BundleCanonical helper + cross-runtime fixture [signet-bdaf24]

### DIFF
--- a/docs/design/cross-language-schema.md
+++ b/docs/design/cross-language-schema.md
@@ -134,8 +134,8 @@ determinism, not byte-equality with the shared fixture.
 
 **Drift canary:** the fxamacker/cbor (Go) and cbor-x (TS) library
 upgrades are the realistic ways this contract can silently break. The
-fixture test is the canary — run `pkg/revocation/...` on a dependency
-bump before shipping.
+fixture test is the canary — run `go test ./pkg/revocation/...` on a
+dependency bump before shipping.
 
 ## How to add a type that needs cross-language sync
 

--- a/docs/design/cross-language-schema.md
+++ b/docs/design/cross-language-schema.md
@@ -97,16 +97,45 @@ channel is governed by the protocol, not the schema:
 | Signet tokens (`SIG1.<CBOR>.<COSE_Sign1>`) | Canonical CBOR per RFC 8949 §4.2, integer-keyed maps | Deterministic bytes for Ed25519 sign/verify; integer keys for compact tokens. See `pkg/revocation/checker.go:168-188`. |
 | CMS / PKCS#7 signatures (git, file signing) | RFC 5652 DER | Sigstore / gpgsm / gitsign compat. |
 | HTTP request bodies (authority API, MCP) | JSON | Standard REST shape; humans read it; not cryptographically canonical. |
-| CA bundle signature input | Canonical CBOR (Go) — see note below | Deterministic bytes for cross-version verification. |
+| CA bundle signature input | Canonical CBOR (RFC 8949 §4.2), integer-keyed map | Deterministic bytes for cross-language Ed25519 sign/verify. |
 
-**Open contract gap (deferred):** Bead `signet-683223` flags
-that TypeScript clients have historically signed `CABundle` with **JSON +
-alphabetical key sort** while Go signs with **canonical CBOR**. These produce
-different byte sequences and are not cryptographically interoperable. The
-capnp schema does not resolve this — schema parity ≠ wire-format parity. This
-contract gap is a separate, **functional** problem and is intentionally **not
-in scope** for the discoverability fix that this doc lands. It needs its own
-bead with a "pick one canonical-bytes encoding, deprecate the other" decision.
+### CABundle canonical-bytes — cross-runtime contract
+
+All three implementations (signet Go, notme TS, cloister TS) produce
+byte-identical CBOR canonical encoding for the same logical `CABundle` input,
+per the schema:
+
+| Field | Map key | Type |
+|---|---|---|
+| `Epoch` | `1` | uint64 |
+| `Seqno` | `2` | uint64 |
+| `Keys` | `3` | `map[string][]byte` (string keys sorted RFC 8949 §4.2: shorter-first then bytewise) |
+| `KeyID` | `4` | string |
+| `PrevKeyID` | `5` | string (empty when unset) |
+| `IssuedAt` | `6` | int64 (Unix seconds) |
+| `Signature` | — | excluded from canonical bytes (verified against them) |
+
+Implementations:
+
+- **signet (Go):** [`pkg/revocation/canonical.go`](../../pkg/revocation/canonical.go) — `BundleCanonical(*types.CABundle) ([]byte, error)` (uses `fxamacker/cbor` with `CanonicalEncOptions`)
+- **notme (TS):** `worker/src/revocation.ts` — `bundleCanonical()` (uses `cbor-x` with `mapsAsObjects: false`, `useRecords: false`, `tagUint8Array: false`)
+- **cloister (TS):** `src/storage/bundle-canonical.ts` — `bundleCanonical()` (mirrors notme's encoder config)
+
+**Cross-runtime fixture.** A 25-byte canonical encoding for a fixed
+input is pinned in tests on the Go side
+([`pkg/revocation/canonical_test.go::TestBundleCanonical_CrossRuntimeFixture`](../../pkg/revocation/canonical_test.go))
+and on the TS side
+([notme/worker/src/__tests__/bundle-canonical.test.ts](https://github.com/agentic-research/notme/blob/main/worker/src/__tests__/bundle-canonical.test.ts) "matches a hand-computed CBOR fixture"). Both
+tests expect the same byte sequence; CI drift on either side breaks the
+cross-language contract immediately. A follow-up bead may lift the
+fixture into `notme/schema/test-vectors/cabundle/` so cloister's
+canonical test pins the same bytes — today cloister only tests its own
+determinism, not byte-equality with the shared fixture.
+
+**Drift canary:** the fxamacker/cbor (Go) and cbor-x (TS) library
+upgrades are the realistic ways this contract can silently break. The
+fixture test is the canary — run `pkg/revocation/...` on a dependency
+bump before shipping.
 
 ## How to add a type that needs cross-language sync
 

--- a/pkg/revocation/canonical.go
+++ b/pkg/revocation/canonical.go
@@ -1,0 +1,59 @@
+package revocation
+
+import (
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+
+	"github.com/agentic-research/signet/pkg/revocation/types"
+)
+
+// BundleCanonical produces the CBOR canonical-bytes signing input for a CABundle.
+//
+// Per signet ADR-002 §2.3 + notme ADR-010, the bytes that get Ed25519-signed
+// are produced via RFC 8949 §4.2 deterministic CBOR encoding over an
+// integer-keyed map:
+//
+//	1: bundle.Epoch
+//	2: bundle.Seqno
+//	3: bundle.Keys
+//	4: bundle.KeyID
+//	5: bundle.PrevKeyID
+//	6: bundle.IssuedAt
+//
+// The Signature field is intentionally excluded — it is what gets verified
+// against this byte sequence, not part of the sign input.
+//
+// Cross-runtime contract: the bytes returned here MUST byte-equal
+// notme/worker/src/revocation.ts bundleCanonical() and
+// cloister/src/storage/bundle-canonical.ts bundleCanonical() for the same
+// logical input. The pinned cross-runtime fixture lives in
+// canonical_test.go (TestBundleCanonical_CrossRuntimeFixture) and matches
+// the 25-byte sequence pinned by notme/worker/src/__tests__/bundle-canonical.test.ts.
+//
+// A fxamacker/cbor library upgrade that changes encoding behavior will
+// break this byte-equality contract silently. The cross-runtime fixture
+// test is the canary — run pkg/revocation/... before bumping the cbor
+// dependency.
+func BundleCanonical(bundle *types.CABundle) ([]byte, error) {
+	if bundle == nil {
+		return nil, fmt.Errorf("revocation: BundleCanonical called with nil bundle")
+	}
+	message := map[int]any{
+		1: bundle.Epoch,
+		2: bundle.Seqno,
+		3: bundle.Keys,
+		4: bundle.KeyID,
+		5: bundle.PrevKeyID,
+		6: bundle.IssuedAt,
+	}
+	encMode, err := cbor.CanonicalEncOptions().EncMode()
+	if err != nil {
+		return nil, fmt.Errorf("revocation: build CBOR canonical encoder: %w", err)
+	}
+	canonical, err := encMode.Marshal(message)
+	if err != nil {
+		return nil, fmt.Errorf("revocation: encode bundle canonical bytes: %w", err)
+	}
+	return canonical, nil
+}

--- a/pkg/revocation/canonical_test.go
+++ b/pkg/revocation/canonical_test.go
@@ -1,0 +1,176 @@
+package revocation
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/agentic-research/signet/pkg/revocation/types"
+)
+
+// TestBundleCanonical_NilBundle asserts that BundleCanonical refuses a nil
+// bundle rather than panicking on the field accesses.
+func TestBundleCanonical_NilBundle(t *testing.T) {
+	if _, err := BundleCanonical(nil); err == nil {
+		t.Fatal("BundleCanonical(nil) should error, got nil")
+	}
+}
+
+// TestBundleCanonical_Deterministic asserts the function returns identical
+// bytes for identical input. Underlying RFC 8949 §4.2 canonical CBOR is
+// deterministic by construction; this test pins the property at the helper
+// boundary so a future refactor can't silently break it.
+func TestBundleCanonical_Deterministic(t *testing.T) {
+	bundle := &types.CABundle{
+		Epoch:     7,
+		Seqno:     3,
+		Keys:      map[string][]byte{"kid1": {0x01, 0x02, 0x03}, "kid2": {0x04, 0x05, 0x06}},
+		KeyID:     "kid1",
+		PrevKeyID: "",
+		IssuedAt:  1_700_000_000,
+		Signature: []byte("ignored"),
+	}
+	a, err := BundleCanonical(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := BundleCanonical(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Fatalf("non-deterministic encoding: %x vs %x", a, b)
+	}
+}
+
+// TestBundleCanonical_SignatureExcluded asserts that the Signature field is
+// not part of the canonical bytes. Changing the signature must not change
+// the verifier's input; otherwise verify would never succeed.
+func TestBundleCanonical_SignatureExcluded(t *testing.T) {
+	base := func() *types.CABundle {
+		return &types.CABundle{
+			Epoch:     1,
+			Seqno:     1,
+			Keys:      map[string][]byte{"kid": {0xab, 0xcd}},
+			KeyID:     "kid",
+			IssuedAt:  1234,
+			Signature: []byte("first"),
+		}
+	}
+	a, err := BundleCanonical(base())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2 := base()
+	b2.Signature = []byte("different")
+	b, err := BundleCanonical(b2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Fatalf("Signature change altered canonical bytes: %x vs %x", a, b)
+	}
+}
+
+// TestBundleCanonical_CrossRuntimeFixture pins the 25-byte canonical encoding
+// for a fixed input. This fixture is shared with the TypeScript reference
+// implementation in
+// notme/worker/src/__tests__/bundle-canonical.test.ts ("matches a
+// hand-computed CBOR fixture") — the byte sequences MUST be identical
+// across both runtimes, otherwise cross-language CABundle verification is
+// silently broken.
+//
+// Fixture inputs (mirrored byte-for-byte from notme's test):
+//
+//	epoch=1, seqno=1, keys={"kid": h'abcd'},
+//	keyId="kid", prevKeyId="", issuedAt=1234, signature ignored.
+//
+// Expected RFC 8949 §4.2 canonical encoding (25 bytes):
+//
+//	a6                          map(6)
+//	  01 01                     1 → 1
+//	  02 01                     2 → 1
+//	  03 a1 63 6b6964 42 abcd   3 → {"kid": h'abcd'}
+//	  04 63 6b6964              4 → "kid"
+//	  05 60                     5 → ""
+//	  06 19 04d2                6 → 1234
+//
+// Drift: this fixture is the canary for a fxamacker/cbor upgrade that
+// would change canonical-encoding behavior. If the bytes diverge here,
+// any signed bundle in the wild produced by the old encoder will fail to
+// verify under the new one. Pin the dependency or audit the diff before
+// taking the upgrade.
+func TestBundleCanonical_CrossRuntimeFixture(t *testing.T) {
+	bundle := &types.CABundle{
+		Epoch:     1,
+		Seqno:     1,
+		Keys:      map[string][]byte{"kid": {0xab, 0xcd}},
+		KeyID:     "kid",
+		PrevKeyID: "",
+		IssuedAt:  1234,
+		Signature: []byte("ignored — must not affect canonical bytes"),
+	}
+	got, err := BundleCanonical(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{
+		0xa6,
+		0x01, 0x01,
+		0x02, 0x01,
+		0x03, 0xa1, 0x63, 0x6b, 0x69, 0x64, 0x42, 0xab, 0xcd,
+		0x04, 0x63, 0x6b, 0x69, 0x64,
+		0x05, 0x60,
+		0x06, 0x19, 0x04, 0xd2,
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("cross-runtime fixture mismatch\n got: %s\nwant: %s",
+			hex.EncodeToString(got), hex.EncodeToString(want))
+	}
+	if len(got) != 25 {
+		t.Fatalf("fixture should be exactly 25 bytes, got %d", len(got))
+	}
+}
+
+// TestBundleCanonical_StringKeyOrderingCanonical pins RFC 8949 §4.2
+// "shorter strings first; equal-length compared bytewise" ordering for
+// string keys inside the Keys map. Mirrors notme's test of the same name
+// ("sorts multi-key keys map per RFC 8949 §4.2 (length-then-bytewise, NOT
+// alphabetical)"). The keys "b" and "ab" are chosen specifically because
+// naive alphabetical sort would place "ab" before "b" (a < b), but
+// canonical sort places "b" first (length 1 < length 2).
+func TestBundleCanonical_StringKeyOrderingCanonical(t *testing.T) {
+	bundle := &types.CABundle{
+		Epoch: 1,
+		Seqno: 1,
+		Keys: map[string][]byte{
+			"ab": {0x02},
+			"b":  {0x01},
+		},
+		KeyID:     "b",
+		PrevKeyID: "",
+		IssuedAt:  1234,
+	}
+	got, err := BundleCanonical(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{
+		0xa6,
+		0x01, 0x01,
+		0x02, 0x01,
+		0x03,
+		0xa2,
+		0x61, 0x62, // "b" — length 1, FIRST per §4.2
+		0x41, 0x01, // h'01'
+		0x62, 0x61, 0x62, // "ab" — length 2, SECOND
+		0x41, 0x02, // h'02'
+		0x04, 0x61, 0x62, // 4 → "b"
+		0x05, 0x60, // 5 → ""
+		0x06, 0x19, 0x04, 0xd2, // 6 → 1234
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("string-key ordering mismatch\n got: %s\nwant: %s",
+			hex.EncodeToString(got), hex.EncodeToString(want))
+	}
+}

--- a/pkg/revocation/checker.go
+++ b/pkg/revocation/checker.go
@@ -12,7 +12,6 @@ import (
 	"github.com/agentic-research/signet/pkg/revocation/cabundle"
 	"github.com/agentic-research/signet/pkg/revocation/types"
 	"github.com/agentic-research/signet/pkg/signet"
-	"github.com/fxamacker/cbor/v2"
 )
 
 const (
@@ -162,30 +161,11 @@ func (c *CABundleChecker) verifyBundleSignature(bundle *types.CABundle) error {
 	copy(signatureCopy, bundle.Signature)
 	defer keys.ZeroizeBytes(signatureCopy) // Clean up sensitive data
 
-	// Create canonical message to verify
-	// We sign the bundle WITHOUT the signature field
-	// Using CBOR integer keys for deterministic encoding
-	message := map[int]interface{}{
-		1: bundle.Epoch,     // epoch
-		2: bundle.Seqno,     // seqno
-		3: bundle.Keys,      // keys map
-		4: bundle.KeyID,     // current key ID
-		5: bundle.PrevKeyID, // previous key ID
-		6: bundle.IssuedAt,  // issued timestamp
-	}
-
-	// Use CBOR deterministic encoding mode to ensure consistent serialization.
-	// IMPORTANT: Bundle signatures depend on bit-identical canonical CBOR across
-	// library versions. A fxamacker/cbor upgrade that changes encoding behavior
-	// will silently break all existing bundle signatures. Pin this dependency or
-	// add a golden-file test when upgrading.
-	encMode, err := cbor.CanonicalEncOptions().EncMode()
-	if err != nil {
-		return fmt.Errorf("failed to create CBOR encoder: %w", err)
-	}
-
-	// Encode to canonical CBOR
-	canonical, err := encMode.Marshal(message)
+	// Build the canonical CBOR signing input via the shared helper. The
+	// helper enforces the cross-runtime contract with notme + cloister
+	// (see canonical.go); changes to the input shape must land there, not
+	// here.
+	canonical, err := BundleCanonical(bundle)
 	if err != nil {
 		return fmt.Errorf("failed to marshal bundle for verification: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes the wire-format-divergence concern from **[signet-bdaf24]** — but the divergence wasn't real. Audit found all three implementations (signet Go, notme TS, cloister TS) **already** use CBOR canonical for the CABundle signing input. The original bead's "TypeScript signs with JSON + alphabetical sort" claim was stale.

What WAS missing — and what [notme's test explicitly flagged as a future bead](https://github.com/agentic-research/notme/blob/main/worker/src/__tests__/bundle-canonical.test.ts) — was a Go-side test pinning the same 25-byte fixture notme's test pins. Without it, three independent CBOR impls claim byte-equality with no CI enforcing it.

## What this PR ships

1. **\`pkg/revocation/canonical.go\` (NEW)** — \`BundleCanonical(*types.CABundle) ([]byte, error)\`. Single source of truth for the canonical-bytes contract; docstring spells out the cross-runtime byte-equality requirement with notme + cloister.
2. **\`pkg/revocation/canonical_test.go\` (NEW)** — 5 tests:
   - nil-bundle guard
   - deterministic encoding
   - signature field excluded from canonical bytes
   - **\`CrossRuntimeFixture\`**: pins the same 25 bytes notme's TS test pins (\`epoch=1, seqno=1, keys={\"kid\":h'abcd'}, keyId=\"kid\", prevKeyId=\"\", issuedAt=1234\`). If fxamacker/cbor or cbor-x ever change canonical-encoding behavior, this test catches it on the Go side.
   - **\`StringKeyOrderingCanonical\`**: pins RFC 8949 §4.2 length-then-bytewise ordering (\"b\" before \"ab\", NOT alphabetical).
3. **\`pkg/revocation/checker.go\`** — \`verifyBundleSignature\` now calls \`BundleCanonical(bundle)\` instead of duplicating the message-map + EncMode locally. ~22 lines deleted.
4. **\`docs/design/cross-language-schema.md\`** — replaces the \"Open contract gap (deferred)\" callout with a concrete \"Cross-runtime contract\" section: field-to-CBOR-key table, links to all three implementations, links to both fixture tests, drift canary note.

## What's still deferred (follow-up bead, not in scope here)

- Lift the 25-byte fixture into \`notme/schema/test-vectors/cabundle/\` so cloister can pin the same bytes (currently cloister only tests its own determinism, not byte-equality with the shared fixture).
- Mechanical replacement of the 9 test-file duplicates of the message-map pattern with \`BundleCanonical()\` calls.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -race ./pkg/revocation/...\` all green
- [x] Cross-runtime fixture produces exactly 25 bytes matching notme's pinned bytes
- [x] String-key ordering matches RFC 8949 §4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)