### PR TITLE
feat(keystore): XDG_CONFIG_HOME routes init + load away from keyring [signet-b30dd4]

### DIFF
--- a/cmd/signet/sign_test.go
+++ b/cmd/signet/sign_test.go
@@ -12,6 +12,12 @@ import (
 )
 
 func TestReproIssue62_MLDSA44_Signing(t *testing.T) {
+	// Force the keyring branch — XDG_CONFIG_HOME is set on CI runners, and
+	// when set the keystore's XDG path takes precedence over the keyring
+	// (signet-b30dd4). ML-DSA-44 is not supported on the XDG path today,
+	// so this test must explicitly opt out of XDG routing.
+	t.Setenv("XDG_CONFIG_HOME", "")
+
 	// 1. Mock the keyring
 	keyring.MockInit()
 

--- a/pkg/cli/keystore/secure.go
+++ b/pkg/cli/keystore/secure.go
@@ -177,6 +177,12 @@ func InitializeSecure(force bool, alg ...algorithm.Algorithm) error {
 	// state and shouldn't be blocked by the developer's real keyring entry.
 	// See signet-b30dd4 for the design rationale.
 	if dir, set := XDGKeystoreDir(); set {
+		// InitializeInsecure only knows how to write Ed25519 today. If the
+		// caller asked for a non-Ed25519 algorithm, refuse explicitly rather
+		// than silently downgrading — a Generic variant is a follow-up.
+		if len(alg) > 0 && alg[0] != "" && alg[0] != algorithm.Ed25519 {
+			return fmt.Errorf("XDG keystore (XDG_CONFIG_HOME=%q): only Ed25519 is supported via the file backend today; %s requires the keyring backend (unset XDG_CONFIG_HOME) — tracked as a follow-up to signet-b30dd4", os.Getenv("XDG_CONFIG_HOME"), alg[0])
+		}
 		return InitializeInsecure(dir, force)
 	}
 
@@ -281,7 +287,11 @@ func InitializeSecure(force bool, alg ...algorithm.Algorithm) error {
 // this caveat applies only to the keyring branch.
 func LoadMasterKeySecure() (*keys.Ed25519Signer, error) {
 	if dir, set := XDGKeystoreDir(); set {
-		return LoadMasterKeyInsecure(dir)
+		signer, err := LoadMasterKeyInsecure(dir)
+		if err != nil {
+			return nil, fmt.Errorf("XDG keystore at %s/master.key: %w (run 'signet-git init' with XDG_CONFIG_HOME set to materialize)", dir, err)
+		}
+		return signer, nil
 	}
 	alg, seed, err := retrieveSeedFromKeyring()
 	if err != nil {
@@ -315,7 +325,7 @@ func LoadMasterKeySecureGeneric() (algorithm.Algorithm, crypto.Signer, error) {
 	if dir, set := XDGKeystoreDir(); set {
 		signer, err := LoadMasterKeyInsecure(dir)
 		if err != nil {
-			return "", nil, err
+			return "", nil, fmt.Errorf("XDG keystore at %s/master.key: %w (run 'signet-git init' with XDG_CONFIG_HOME set to materialize)", dir, err)
 		}
 		// LoadMasterKeyInsecure always returns Ed25519 (current behavior);
 		// non-Ed25519 algorithms via the XDG file path land as a follow-up.
@@ -355,7 +365,11 @@ func LoadMasterKeySecureGeneric() (algorithm.Algorithm, crypto.Signer, error) {
 // until garbage collected. See package-level documentation for more details.
 func GetKeyIDSecure() (string, error) {
 	if dir, set := XDGKeystoreDir(); set {
-		return GetKeyIDInsecure(dir)
+		kid, err := GetKeyIDInsecure(dir)
+		if err != nil {
+			return "", fmt.Errorf("XDG keystore at %s/master.key: %w (run 'signet-git init' with XDG_CONFIG_HOME set to materialize)", dir, err)
+		}
+		return kid, nil
 	}
 	alg, seed, err := retrieveSeedFromKeyring()
 	if err != nil {

--- a/pkg/cli/keystore/secure.go
+++ b/pkg/cli/keystore/secure.go
@@ -171,6 +171,15 @@ func readSeedFromPEM(keyPath string, checkPermissions bool) ([]byte, error) {
 // InitializeSecure generates a master key and stores it in the OS keyring.
 // The alg parameter specifies which algorithm to use (empty string defaults to Ed25519).
 func InitializeSecure(force bool, alg ...algorithm.Algorithm) error {
+	// XDG_CONFIG_HOME, when set, takes precedence: write to the file path
+	// rather than the OS keyring. The keyring's existing-key-check is also
+	// skipped — XDG callers (test harnesses, CI runners) want isolated
+	// state and shouldn't be blocked by the developer's real keyring entry.
+	// See signet-b30dd4 for the design rationale.
+	if dir, set := XDGKeystoreDir(); set {
+		return InitializeInsecure(dir, force)
+	}
+
 	// Determine algorithm
 	selectedAlg := algorithm.DefaultAlgorithm
 	if len(alg) > 0 && alg[0] != "" {
@@ -253,15 +262,27 @@ func InitializeSecure(force bool, alg ...algorithm.Algorithm) error {
 	})
 }
 
-// LoadMasterKeySecure loads the master key from the OS keyring.
+// LoadMasterKeySecure loads the master key from the OS keyring — unless
+// XDG_CONFIG_HOME is set, in which case it loads from
+// $XDG_CONFIG_HOME/signet/master.key and skips the keyring entirely.
+//
+// The XDG-takes-precedence rule is deliberate (see signet-b30dd4): it
+// gives a deterministic, per-process keystore-isolation path without
+// adding a new CLI flag or touching the user's real keyring. Default
+// behavior (XDG unset) is preserved bit-for-bit.
+//
 // Returns a crypto.Signer that the caller must Destroy() when done
 // (if the signer implements a Destroy() method).
 //
-// SECURITY: This function returns a key derived from a secret that is loaded
-// into memory as a string. Due to Go's string immutability, the secret may
-// persist in memory until garbage collected. See package-level documentation
-// for more details.
+// SECURITY: When loading from the keyring this function returns a key
+// derived from a secret loaded into memory as a string. Due to Go's
+// string immutability, the secret may persist in memory until garbage
+// collected. The XDG/file path uses defensive byte-slice handling so
+// this caveat applies only to the keyring branch.
 func LoadMasterKeySecure() (*keys.Ed25519Signer, error) {
+	if dir, set := XDGKeystoreDir(); set {
+		return LoadMasterKeyInsecure(dir)
+	}
 	alg, seed, err := retrieveSeedFromKeyring()
 	if err != nil {
 		return nil, err
@@ -284,9 +305,22 @@ func LoadMasterKeySecure() (*keys.Ed25519Signer, error) {
 	})
 }
 
-// LoadMasterKeySecureGeneric loads any algorithm's master key from the OS keyring.
+// LoadMasterKeySecureGeneric loads any algorithm's master key from the OS
+// keyring, or — when XDG_CONFIG_HOME is set — from
+// $XDG_CONFIG_HOME/signet/master.key. See LoadMasterKeySecure for the
+// rationale.
+//
 // Returns the algorithm used and a crypto.Signer.
 func LoadMasterKeySecureGeneric() (algorithm.Algorithm, crypto.Signer, error) {
+	if dir, set := XDGKeystoreDir(); set {
+		signer, err := LoadMasterKeyInsecure(dir)
+		if err != nil {
+			return "", nil, err
+		}
+		// LoadMasterKeyInsecure always returns Ed25519 (current behavior);
+		// non-Ed25519 algorithms via the XDG file path land as a follow-up.
+		return algorithm.Ed25519, signer, nil
+	}
 	alg, seed, err := retrieveSeedFromKeyring()
 	if err != nil {
 		return "", nil, err
@@ -320,6 +354,9 @@ func LoadMasterKeySecureGeneric() (algorithm.Algorithm, crypto.Signer, error) {
 // string. Due to Go's string immutability, the secret may persist in memory
 // until garbage collected. See package-level documentation for more details.
 func GetKeyIDSecure() (string, error) {
+	if dir, set := XDGKeystoreDir(); set {
+		return GetKeyIDInsecure(dir)
+	}
 	alg, seed, err := retrieveSeedFromKeyring()
 	if err != nil {
 		return "", err

--- a/pkg/cli/keystore/secure_test.go
+++ b/pkg/cli/keystore/secure_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func TestSecureKeystore(t *testing.T) {
+	// Force the keyring branch — CI runners set XDG_CONFIG_HOME in the env,
+	// which would otherwise route this test through the file-based path
+	// added in signet-b30dd4 (XDG-aware loader).
+	t.Setenv("XDG_CONFIG_HOME", "")
+
 	// Use mock keyring for testing
 	keyring.MockInit()
 
@@ -87,6 +92,9 @@ func TestSecureKeystore(t *testing.T) {
 }
 
 func TestSecureKeystoreNotFound(t *testing.T) {
+	// Force the keyring branch — see TestSecureKeystore for rationale.
+	t.Setenv("XDG_CONFIG_HOME", "")
+
 	// Use mock keyring for testing
 	keyring.MockInit()
 
@@ -109,6 +117,9 @@ func TestSecureKeystoreNotFound(t *testing.T) {
 }
 
 func TestCorruptedKeyringData(t *testing.T) {
+	// Force the keyring branch — see TestSecureKeystore for rationale.
+	t.Setenv("XDG_CONFIG_HOME", "")
+
 	// Use a mock keyring for this test
 	keyring.MockInit()
 

--- a/pkg/cli/keystore/xdg.go
+++ b/pkg/cli/keystore/xdg.go
@@ -1,0 +1,34 @@
+package keystore
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// XDGKeystoreDir returns the signet keystore directory derived from
+// XDG_CONFIG_HOME if that environment variable is set.
+//
+// Behavior:
+//   - XDG_CONFIG_HOME set → returns ("$XDG_CONFIG_HOME/signet", true).
+//     Callers MUST use this path for both reads and writes; the OS keyring
+//     is skipped entirely. This is the canonical test/CI/ephemeral path —
+//     `XDG_CONFIG_HOME=$(mktemp -d) signet-git init` puts the master key in
+//     an isolated tmpdir without touching the user's real keyring.
+//   - XDG_CONFIG_HOME unset → returns ("", false). Callers should use the
+//     existing OS keyring path (bit-for-bit backward compatible).
+//
+// We intentionally do NOT fall back to the XDG-spec default of
+// $HOME/.config/signet when XDG_CONFIG_HOME is unset. That would be a
+// silent behavior change for any developer who has ~/.config but has
+// always used the keyring — they'd suddenly start reading from a
+// nonexistent file and fail. Requiring explicit XDG_CONFIG_HOME is the
+// opt-in signal.
+//
+// See signet-b30dd4 for the design discussion.
+func XDGKeystoreDir() (dir string, set bool) {
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+	if xdg == "" {
+		return "", false
+	}
+	return filepath.Join(xdg, "signet"), true
+}

--- a/pkg/cli/keystore/xdg_test.go
+++ b/pkg/cli/keystore/xdg_test.go
@@ -1,0 +1,102 @@
+package keystore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestXDGKeystoreDir_Unset(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	dir, set := XDGKeystoreDir()
+	if set {
+		t.Fatalf("XDG_CONFIG_HOME unset: expected set=false, got set=true (dir=%q)", dir)
+	}
+	if dir != "" {
+		t.Fatalf("XDG_CONFIG_HOME unset: expected dir=\"\", got %q", dir)
+	}
+}
+
+func TestXDGKeystoreDir_Set(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir, set := XDGKeystoreDir()
+	if !set {
+		t.Fatal("XDG_CONFIG_HOME set: expected set=true, got set=false")
+	}
+	want := filepath.Join(tmp, "signet")
+	if dir != want {
+		t.Fatalf("XDG_CONFIG_HOME=%q: expected dir=%q, got %q", tmp, want, dir)
+	}
+}
+
+// TestXDGRoutesInitAndLoad is the dogfood-grade end-to-end test that
+// closes signet-b30dd4. With XDG_CONFIG_HOME set to a fresh tmp dir,
+// init writes to that dir AND a subsequent LoadMasterKeySecure /
+// GetKeyIDSecure reads from that dir — the OS keyring is bypassed
+// entirely.
+//
+// This was the failing scenario at b30dd4's filing: previously,
+// init would write to the keyring regardless of any path hint, and
+// LoadMasterKeySecure would always check the keyring first, so an
+// "isolated" home was a lie. With XDG support, the env var is the
+// hard switch.
+func TestXDGRoutesInitAndLoad(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	// Init: should write master.key under $XDG_CONFIG_HOME/signet/, not
+	// the user's keyring.
+	if err := InitializeSecure(false); err != nil {
+		t.Fatalf("InitializeSecure with XDG_CONFIG_HOME set: %v", err)
+	}
+
+	keyPath := filepath.Join(tmp, "signet", "master.key")
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("expected master.key at %s, stat error: %v", keyPath, err)
+	}
+
+	// Load: should read from the XDG dir, NOT the OS keyring. If
+	// LoadMasterKeySecure still hit the keyring first, this would
+	// either succeed against the developer's real key (returning a
+	// different KID than the freshly-written one) or fail when no
+	// keyring entry exists. Both are bugs.
+	signer, err := LoadMasterKeySecure()
+	if err != nil {
+		t.Fatalf("LoadMasterKeySecure with XDG_CONFIG_HOME set: %v", err)
+	}
+	signer.Destroy()
+
+	// GetKeyIDSecure should also be XDG-aware. Its return value must
+	// match GetKeyIDInsecure against the same path.
+	xdgKID, err := GetKeyIDInsecure(filepath.Join(tmp, "signet"))
+	if err != nil {
+		t.Fatalf("GetKeyIDInsecure against XDG dir: %v", err)
+	}
+	secureKID, err := GetKeyIDSecure()
+	if err != nil {
+		t.Fatalf("GetKeyIDSecure with XDG_CONFIG_HOME set: %v", err)
+	}
+	if xdgKID != secureKID {
+		t.Fatalf("GetKeyIDSecure (XDG-routed) returned %q but GetKeyIDInsecure (direct) returned %q — XDG routing is leaking to keyring", secureKID, xdgKID)
+	}
+}
+
+// TestXDGForceReinit confirms --force re-initialization works through
+// the XDG path (the keyring's existing-key-check is correctly skipped
+// when XDG is set).
+func TestXDGForceReinit(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if err := InitializeSecure(false); err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	if err := InitializeSecure(false); err == nil {
+		t.Fatal("second init without --force should fail (key exists)")
+	}
+	if err := InitializeSecure(true); err != nil {
+		t.Fatalf("second init with --force should succeed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the dogfood-grade UX gap from **[signet-b30dd4]**: previously, even with `--home` pointed at a tmp dir, signet-git would hit the OS keyring first. The \"isolated test home\" was a lie — `export-key-id` under any `--home` returned the user's **real** keyring KID.

This PR adds `XDG_CONFIG_HOME`-as-keystore-override using the standard Unix convention rather than a new `--keystore=` flag:

\`\`\`sh
XDG_CONFIG_HOME=$(mktemp -d) signet-git init            # writes isolated file
XDG_CONFIG_HOME=$(mktemp -d) signet-git export-key-id   # reads isolated file
\`\`\`

The OS keyring is bypassed entirely when XDG_CONFIG_HOME is set. When unset, behavior is bit-for-bit identical to today's keyring-first flow — zero regression for the default case.

## Changes

- **\`pkg/cli/keystore/xdg.go\` (NEW)**: \`XDGKeystoreDir()\` returns \`($XDG_CONFIG_HOME/signet, true)\` when set, \`(\"\", false)\` otherwise. Does NOT silently default to \`~/.config\` — requires explicit env-var opt-in to avoid breaking users with \`~/.config\` directories who always used the keyring.
- **\`pkg/cli/keystore/secure.go\`**: \`InitializeSecure\`, \`LoadMasterKeySecure\`, \`LoadMasterKeySecureGeneric\`, \`GetKeyIDSecure\` all consult XDG first and delegate to the file path when set.
- **\`pkg/cli/keystore/xdg_test.go\` (NEW)**: 4 tests including the dogfood-grade \`TestXDGRoutesInitAndLoad\` that proves init+load+KID-export all route to the XDG dir and skip the keyring.

## Dogfood (real binary)

\`\`\`
$ XDG_CONFIG_HOME=$(mktemp -d) signet-git init
Master key generated: 294c311d...  ← NEW, isolated
$ XDG_CONFIG_HOME=$dir signet-git export-key-id
294c311d...                          ← XDG-isolated KID
$ signet-git export-key-id           ← without XDG
4eb3f728...                          ← user's real keyring, untouched
\`\`\`

Plus a full sign+verify roundtrip through the isolated XDG home produced a valid CMS \`SIGNED MESSAGE\` and verify returned \`✓\` — proving the whole pipeline works without touching the user's real keyring.

## What stays open in b30dd4

- Rename / deprecate the \`--insecure\` flag (cosmetic; the path XDG_CONFIG_HOME unlocks is no longer \"insecure\" — it's the canonical test mode).
- Audit other \`LoadMasterKeyInsecure\` callsites for whether they should also accept XDG paths.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -race ./pkg/cli/keystore/ ./pkg/git/ ./cmd/...\` all green
- [x] 4 new XDG tests pass
- [x] Real-binary dogfood: XDG routes init+export-key-id away from keyring; full sign+verify roundtrip ✓
- [x] User's real keystore (\`~/.signet\`, OS keyring) untouched by any test

🤖 Generated with [Claude Code](https://claude.com/claude-code)