### PR TITLE
feat(authority): signet authority pubkey — one-line trust-anchor export

### DIFF
--- a/cmd/signet/authority_pubkey.go
+++ b/cmd/signet/authority_pubkey.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/agentic-research/signet/pkg/cli/keystore"
+)
+
+// authorityPubkey* flags are CLI-only state for `signet authority pubkey`.
+var (
+	pubkeyURL     string
+	pubkeyURLPath string
+	pubkeyTimeout time.Duration
+)
+
+// authorityPubkeyCmd prints the authority's master Ed25519 public key as
+// base64-encoded raw bytes. Consumers (cloister `INTERLACE_ROOT_PUBKEY`,
+// notme verifiers) pin this value as their trust anchor.
+//
+// Two modes:
+//
+//   - **Local (default):** load from this machine's keystore (OS keyring, or
+//     $XDG_CONFIG_HOME/signet/master.key when XDG_CONFIG_HOME is set).
+//   - **Remote (--url):** fetch /.well-known/ca-bundle.pem from a running
+//     authority — local Go binary OR remote notme worker — and extract
+//     the master pubkey from the X.509 CA certificate.
+//
+// Output: base64-standard-encoded 32-byte Ed25519 raw pubkey, one line, no
+// header/footer. Designed to be embedded in shell-glue like
+// `INTERLACE_ROOT_PUBKEY=$(signet authority pubkey)`.
+var authorityPubkeyCmd = &cobra.Command{
+	Use:   "pubkey",
+	Short: "Print the authority's master public key as base64",
+	Long: `Print the master Ed25519 public key (base64-encoded raw bytes) that
+downstream verifiers (cloister, notme consumers) pin as their trust anchor
+(INTERLACE_ROOT_PUBKEY).
+
+By default loads the key from this machine's keystore: the OS keyring, or
+$XDG_CONFIG_HOME/signet/master.key when XDG_CONFIG_HOME is set.
+
+With --url, fetches /.well-known/ca-bundle.pem from a running authority
+(local Go binary OR remote notme worker), parses the X.509 CA certificate,
+and extracts the public key. Use this when bootstrapping a cloister
+.env.local from an authority you don't control directly.`,
+	Example: `  # Local mode: read from this machine's keystore
+  signet authority pubkey
+
+  # Remote mode: fetch from a running authority
+  signet authority pubkey --url http://localhost:8080
+  signet authority pubkey --url https://auth.notme.bot
+
+  # Wire into a cloister dev bootstrap
+  echo "INTERLACE_ROOT_PUBKEY=$(signet authority pubkey)" >> .env.local`,
+	RunE:          runAuthorityPubkey,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	authorityPubkeyCmd.Flags().StringVar(&pubkeyURL, "url", "", "Fetch from a running authority (e.g. http://localhost:8080, https://auth.notme.bot)")
+	authorityPubkeyCmd.Flags().StringVar(&pubkeyURLPath, "path", "/.well-known/ca-bundle.pem", "URL path to fetch the CA bundle PEM from")
+	authorityPubkeyCmd.Flags().DurationVar(&pubkeyTimeout, "timeout", 5*time.Second, "HTTP timeout for --url mode")
+	authorityCmd.AddCommand(authorityPubkeyCmd)
+}
+
+func runAuthorityPubkey(cmd *cobra.Command, _ []string) error {
+	var pubkey []byte
+	var err error
+	if pubkeyURL == "" {
+		pubkey, err = pubkeyFromLocalKeystore()
+		if err != nil {
+			return fmt.Errorf("local keystore: %w", err)
+		}
+	} else {
+		pubkey, err = pubkeyFromURL(cmd.Context(), pubkeyURL, pubkeyURLPath, pubkeyTimeout)
+		if err != nil {
+			return fmt.Errorf("fetch from %s: %w", pubkeyURL, err)
+		}
+	}
+	fmt.Println(base64.StdEncoding.EncodeToString(pubkey))
+	return nil
+}
+
+// pubkeyFromLocalKeystore reads the master Ed25519 public key from the
+// active keystore (XDG file or OS keyring, controlled by the existing
+// keystore-routing rules) and returns its 32 raw bytes.
+func pubkeyFromLocalKeystore() ([]byte, error) {
+	signer, err := keystore.LoadMasterKeySecure()
+	if err != nil {
+		return nil, err
+	}
+	defer signer.Destroy()
+	pub, ok := signer.Public().(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("master key is not Ed25519 (got %T)", signer.Public())
+	}
+	return []byte(pub), nil
+}
+
+// pubkeyFromURL fetches the CA bundle PEM from a running authority,
+// parses the embedded X.509 certificate, and returns the certificate's
+// Ed25519 public key as 32 raw bytes.
+//
+// Body size is capped at 1 MiB — a legitimate CA bundle PEM is well under
+// 4 KiB; the cap is a defense against a hostile authority streaming
+// arbitrary bytes into the parser.
+func pubkeyFromURL(ctx context.Context, base, urlPath string, timeout time.Duration) ([]byte, error) {
+	full := strings.TrimRight(base, "/") + urlPath
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, full, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", full, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d", full, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	block, _ := pem.Decode(body)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, errors.New("response is not a PEM CERTIFICATE block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse certificate: %w", err)
+	}
+	pub, ok := cert.PublicKey.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("certificate public key is not Ed25519 (got %T)", cert.PublicKey)
+	}
+	return []byte(pub), nil
+}

--- a/cmd/signet/authority_pubkey.go
+++ b/cmd/signet/authority_pubkey.go
@@ -128,7 +128,7 @@ func pubkeyFromURL(ctx context.Context, base, urlPath string, timeout time.Durat
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", full, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET %s: HTTP %d", full, resp.StatusCode)
 	}

--- a/cmd/signet/authority_pubkey_test.go
+++ b/cmd/signet/authority_pubkey_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestPubkeyFromLocalKeystore_XDG initializes a fresh XDG-isolated
+// keystore, runs the local-keystore path of `signet authority pubkey`,
+// and asserts the output round-trips a known Ed25519 public key.
+//
+// This is the "dev bootstrap" code path: a developer runs `signet-git
+// init` against an isolated home, then `signet authority pubkey` against
+// the same home, and pipes the output into `INTERLACE_ROOT_PUBKEY=...`
+// in cloister's .env.local.
+func TestPubkeyFromLocalKeystore_XDG(t *testing.T) {
+	// Generate a known Ed25519 keypair and write the seed to an
+	// XDG-style file ourselves (skipping signet-git init to keep the
+	// test contained to authority_pubkey.go's surface). We use the
+	// same PEM type and 0600 permissions InitializeInsecure does.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed := priv.Seed()
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "ED25519 PRIVATE KEY",
+		Bytes: seed,
+	})
+	keyDir := filepath.Join(tmp, "signet")
+	if err := mkdir0700(keyDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFile0600(filepath.Join(keyDir, "master.key"), pemBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := pubkeyFromLocalKeystore()
+	if err != nil {
+		t.Fatalf("pubkeyFromLocalKeystore: %v", err)
+	}
+	if len(got) != ed25519.PublicKeySize {
+		t.Fatalf("got %d bytes, want %d (Ed25519 pubkey size)", len(got), ed25519.PublicKeySize)
+	}
+	if !ed25519Equal(got, []byte(pub)) {
+		t.Fatalf("pubkey mismatch:\n  got:  %x\n  want: %x", got, []byte(pub))
+	}
+
+	// Also verify the full subcommand stdout shape: base64 line, no
+	// header/footer. Use the same data via runAuthorityPubkey's path.
+	encoded := base64.StdEncoding.EncodeToString(got)
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("base64 round-trip: %v", err)
+	}
+	if !ed25519Equal(decoded, got) {
+		t.Fatal("base64 round-trip changed bytes")
+	}
+}
+
+// TestPubkeyFromURL spins up an httptest server that serves a
+// known-key PEM CA cert at /.well-known/ca-bundle.pem, fetches it via
+// the same code path that `signet authority pubkey --url <X>` takes,
+// and asserts the returned bytes match the original public key.
+func TestPubkeyFromURL(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPEM := selfSignedCAPem(t, priv, pub)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/ca-bundle.pem", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-pem-file")
+		_, _ = w.Write(caPEM)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	got, err := pubkeyFromURL(context.Background(), srv.URL, "/.well-known/ca-bundle.pem", 5*time.Second)
+	if err != nil {
+		t.Fatalf("pubkeyFromURL: %v", err)
+	}
+	if !ed25519Equal(got, []byte(pub)) {
+		t.Fatalf("pubkey mismatch:\n  got:  %x\n  want: %x", got, []byte(pub))
+	}
+}
+
+// TestPubkeyFromURL_Non200 rejects responses that aren't 200 OK with
+// an actionable error.
+func TestPubkeyFromURL_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+	_, err := pubkeyFromURL(context.Background(), srv.URL, "/.well-known/ca-bundle.pem", 1*time.Second)
+	if err == nil {
+		t.Fatal("expected error on 503, got nil")
+	}
+}
+
+// TestPubkeyFromURL_NotPEM rejects bodies that are not PEM-encoded.
+func TestPubkeyFromURL_NotPEM(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello, world — not a PEM block"))
+	}))
+	t.Cleanup(srv.Close)
+	_, err := pubkeyFromURL(context.Background(), srv.URL, "/.well-known/ca-bundle.pem", 1*time.Second)
+	if err == nil {
+		t.Fatal("expected error on non-PEM body, got nil")
+	}
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+func ed25519Equal(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func selfSignedCAPem(t *testing.T, priv ed25519.PrivateKey, pub ed25519.PublicKey) []byte {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-authority"},
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func mkdir0700(dir string) error {
+	return os.MkdirAll(dir, 0o700)
+}
+
+func writeFile0600(path string, b []byte) error {
+	return os.WriteFile(path, b, 0o600)
+}


### PR DESCRIPTION
## Summary

Adds `signet authority pubkey` — a one-line export path for the master Ed25519 public key that cloister pins as `INTERLACE_ROOT_PUBKEY` (the lease-gate switch) and notme verifiers consume.

Companion cloister PR will wire this into `scripts/dev-bootstrap.mjs` so `task dev:bootstrap` materializes `INTERLACE_ROOT_PUBKEY` automatically.

## What's changing

Two modes:

\`\`\`
signet authority pubkey
  → load from this machine's keystore (XDG file or OS keyring per signet-b30dd4 routing)

signet authority pubkey --url https://auth.notme.bot
  → fetch /.well-known/ca-bundle.pem, parse X.509 CA cert, extract Ed25519 pubkey
\`\`\`

Output: base64-standard-encoded 32-byte Ed25519 raw pubkey, one line, no header/footer. Designed for shell glue:

\`\`\`
INTERLACE_ROOT_PUBKEY=\$(signet authority pubkey)
\`\`\`

## Why

Before this PR, populating `INTERLACE_ROOT_PUBKEY` required: start an authority, hand-fetch the CA bundle PEM, openssl x509 -pubkey, parse, base64-encode the raw 32 bytes, paste into .env.local. Four-step shell-foo not documented in either repo.

The user described it as "unclear how / where / what's needed tbh" — this PR closes that.

## Test plan

- [x] \`go test ./cmd/signet/ -run 'TestPubkey'\` — 4 tests pass (local-keystore + remote-URL happy path, 503 rejection, non-PEM rejection)
- [x] Dogfood with real binaries: init isolated XDG keystore, run \`signet authority pubkey\`, base64-decode the output, hex-encode, compare to \`signet-git export-key-id\` — bytes match exactly

## Security

The subcommand emits *public* key material only. The local-keystore branch loads the master key only to read \`.Public()\` and \`.Destroy()\`s the signer immediately. The URL path caps response body at 1 MiB as defense against a hostile authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)